### PR TITLE
fix no such variable: preprocess, in assembly sub wf

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -750,9 +750,17 @@ workflow {
         busco_db = download_busco()
         dammit_db = extract_tar_bz2(download_dammit(busco_db))
         // de novo
-        assembly_denovo(preprocess.out.cleaned_reads_ch, busco_db, dammit_db)
-        // reference-based
-        assembly_reference(reference, annotation, preprocess.out.sample_bam_ch, busco_db, dammit_db)
+        if (!params.nanopore) {
+            // de novo
+            assembly_denovo(preprocess_illumina.out.cleaned_reads_ch, busco_db, dammit_db)
+            // reference-based
+            assembly_reference(reference, annotation, preprocess_illumina.out.sample_bam_ch, busco_db, dammit_db)
+        } else {
+            // de novo
+            assembly_denovo(preprocess_nanopore.out.cleaned_reads_ch, busco_db, dammit_db)
+            // reference-based
+            assembly_reference(reference, annotation, preprocess_nanopore.out.sample_bam_ch, busco_db, dammit_db)
+        }
     } else {
     // perform expression analysis
         // start reference-based differential gene expression analysis


### PR DESCRIPTION
when running with --assembly nextflow throws an error because variable preprocess is not found, i think this is because of 
https://github.com/hoelzer-lab/rnaflow/blob/master/main.nf#L753
and 
https://github.com/hoelzer-lab/rnaflow/blob/master/main.nf#L755

there are only channels preprocess_illumina.out and preprocess_nanopore.out, maybe this happened while implementing the nanopore support.