### PR TITLE
flip log fc

### DIFF
--- a/bin/deseq2.R
+++ b/bin/deseq2.R
@@ -534,8 +534,8 @@ for (comparison in comparisons) {
   ##########################################
 
   factor <- "condition"
-  numerator <- l2
-  denominator <- l1
+  numerator <- l1
+  denominator <- l2
   group <- colData(dds)[[factor]]
   group <- relevel(x = group, ref = denominator)
   colData(dds)[[factor]] <- group


### PR DESCRIPTION
We used the pipeline for a DEG analysis and found the following unexpected behavior:

If you compare _infected vs. mock_, then people expect that:
```
If logFC > 0, then   **up** in infected and **down** in mock
If logFC < 0, then **down** in infected and   **up** in mock
```

Currently, it's the other way around (regarding the logFC sign) and I think we should change it - at least if there is no fallacy.