### PR TITLE
fix pipeline crashing for long reads longer than 30k nt because of SMR, closes #162

### DIFF
--- a/modules/sortmerna.nf
+++ b/modules/sortmerna.nf
@@ -6,6 +6,8 @@
 process sortmerna {
     label 'sortmerna'
 
+    if ( params.nanopore ) { errorStrategy 'ignore' }
+
     if ( params.softlink_results ) { publishDir "${params.output}/${params.sortmerna_dir}", pattern: "*.other.fastq.gz" }
     else { publishDir "${params.output}/${params.sortmerna_dir}", mode: 'copy', pattern: "*.other.fastq.gz" }
 


### PR DESCRIPTION
Issue: SMR fails if it finds reads with length > 30000 nt because they are not supported by SMR. This crashes the whole pipeline.

Quickfix is to just ignore SMR errors when running in nanopore mode and hope for the best.