### PR TITLE
update multiqc to v1.12, add python v3.10 explicitly, closes #183

### DIFF
--- a/configs/container.config
+++ b/configs/container.config
@@ -6,7 +6,7 @@ process {
     withLabel:	fastp	{ container = "nanozoo/fastp:0.23.1--9f2e255" } 
     withLabel:	fastqc	{ container = "nanozoo/fastqc:0.11.8--fbfa1d7" } 
     withLabel:	subread	{ container = "nanozoo/subread:2.0.1--713a8e7" } 
-    withLabel:	multiqc	{ container = "nanozoo/multiqc:1.11--9dfdee6" } 
+    withLabel:	multiqc	{ container = "nanozoo/multiqc:1.12--4f89fda" } 
     withLabel:	nanoplot	{ container = "nanozoo/nanoplot:1.38.1--e303519" }
     withLabel:	sortmerna	{ container = "nanozoo/sortmerna:2.1b--ceea1a1" } 
     withLabel:	trinity	{ container = "trinityrnaseq/trinityrnaseq:2.13.2" } 

--- a/envs/multiqc.yaml
+++ b/envs/multiqc.yaml
@@ -3,4 +3,5 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - multiqc=1.11
+  - multiqc=1.12
+  - python=3.10


### PR DESCRIPTION
- update multiqc to v1.12 in env and container
- add python 3.10 to multiqc env and container