### PR TITLE
feature type is not considered and overwritten by feature attribute type 

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -287,7 +287,7 @@ if ( params.featurecounts_additional_params.contains('-g ') ){
     }
 } else {
     gtf_attr_type_ch = Channel.value('gene_id')
-    gtf_feature_type_of_attr_type_ch = Channel.value('gene')
+    gtf_feature_type_of_attr_type_ch = Channel.value('gene') //where is this actually needed ? we never filter after attr type feature type
 }
 
 /*

--- a/main.nf
+++ b/main.nf
@@ -650,8 +650,8 @@ workflow expression_reference_based {
         featurecounts(sample_bam_ch, annotation, params.featurecounts_additional_params)
 
         // prepare annotation for R input
-        format_annotation_gene_rows(annotation, gtf_feature_type_of_attr_type_ch)
-        format_annotation(annotation, gtf_attr_type_ch, gtf_feature_type_of_attr_type_ch)
+        format_annotation_gene_rows(annotation, gtf_feature_type_ch)
+        format_annotation(annotation, gtf_attr_type_ch, gtf_feature_type_ch)
 
         // filter by TPM value
         // prepare input channels


### PR DESCRIPTION
The feature type is read from the `--featurecounts_additional_params -t exon -g gene_id` parameter:
https://github.com/hoelzer-lab/rnaflow/blob/fix_anno_feature_type/main.nf#L274

But then we never actually used this value, instead the `format_annotation_rows` and `format_annotation` processes are filtering for features of type feature_type_attribute_type in line:
https://github.com/hoelzer-lab/rnaflow/blob/fix_anno_feature_type/main.nf#L285

The feature_type_attribute_type defaults to the beginning of `gene_id` -> so `gene`. But the actual default feature type is `exon` right?

This leads to `format_annotation_rows` and `format_annotation` processes filtering out every feature if the GTF contains only features that are not of type gene, even when the feature type is explicitly set to not be gene, but the attribute type starts with gene (see #187).

I'm not quite sure where we ever need the feature type attribute type? Maybe you could tell me :D