### PR TITLE
fix channel order in expression_reference_based sub-wf, closes #191

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -655,9 +655,9 @@ workflow expression_reference_based {
         deseq2_script_refactor_reportingtools_table
         deseq2_script_improve_deseq_table
         multiqc_config
-        species2prefix
         piano_script
         webgestalt_script
+        species2prefix
 
     main:
         // count with featurecounts


### PR DESCRIPTION
fix channel order in sub-wf expression_reference_based that caused the `webgestalt` process to load the ens_species_mapping file instead of the webgestalt.R script resulting in a pipeline crash