### PR TITLE
explicitly enable conda in conda profile

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -156,6 +156,7 @@ profiles {
         // can be removed if we have working conda envs for all tools!
         docker { enabled = true }
         conda{
+            enabled = true
             cacheDir = params.condaCacheDir
             timeout = '45 min'
             useMamba = true


### PR DESCRIPTION
Since Nextflow version 22.07 the conda option has to be explicitly enabled in the config via `conda.enabled = true`
otherwise no conda environments will be created or used and all processes fail with 'command xy not found'.
(Had to find out about this when updating Nextflow and all the pipelines stopped working :heart_eyes: )