### PR TITLE
Fix pca plots and  ENS ID lookup for non ENS IDs

### DIFF
--- a/bin/deseq2.R
+++ b/bin/deseq2.R
@@ -133,8 +133,7 @@ plot.pca <- function(out.dir, col.labels, trsf_data, trsf_type, ntop) {
   }
 
   d <- data.frame(PC1=pca$x[,1], PC2=pca$x[,2], group=group, intgroup.df, name=col.labels)
-  print("pca df is:")
-  print(d)
+
   ggplot(data=d, aes(x=PC1, y=PC2, colour=condition)) +
     geom_point(size=3) + 
     xlab(paste0("PC1: ",round(percentVar[1] * 100),"% variance")) +

--- a/bin/deseq2.R
+++ b/bin/deseq2.R
@@ -133,8 +133,9 @@ plot.pca <- function(out.dir, col.labels, trsf_data, trsf_type, ntop) {
   }
 
   d <- data.frame(PC1=pca$x[,1], PC2=pca$x[,2], group=group, intgroup.df, name=col.labels)
-
-  ggplot(data=d, aes(x="PC1", y="PC2", colour="condition")) +
+  print("pca df is:")
+  print(d)
+  ggplot(data=d, aes(x=PC1, y=PC2, colour=condition)) +
     geom_point(size=3) + 
     xlab(paste0("PC1: ",round(percentVar[1] * 100),"% variance")) +
     ylab(paste0("PC2: ",round(percentVar[2] * 100),"% variance")) +
@@ -143,6 +144,7 @@ plot.pca <- function(out.dir, col.labels, trsf_data, trsf_type, ntop) {
 
   ggsave(file = paste0("PCA_simple_", trsf_type, "_top", ntop, ".pdf"), device = "pdf", path = out.dir)
   ggsave(file = paste0("PCA_simple_", trsf_type, "_top", ntop, ".svg"), device = "svg", path = out.dir)
+  print(paste0("PCA_simple_", trsf_type, "_top", ntop, ".pdf"))
 }
 
 plot.heatmap.most_var <- function(out.dir, dds, trsf_data, trsf_type, ntop, samples.info=df.samples.info, genes.info=df.gene.anno) {

--- a/bin/refactor_reportingtools_table.rb
+++ b/bin/refactor_reportingtools_table.rb
@@ -99,6 +99,8 @@ class RefactorReportingtoolsTable
       refactor_deseq_html_table(html_path)
     end
   end
+
+  puts $id2pos
   
   def add_plot_html_code(html_path, pvalue)
 
@@ -158,7 +160,8 @@ class RefactorReportingtoolsTable
           feature_id = feature_id.gsub('"','')
           feature_name = $id2name[feature_id]
           gene_biotype = $id2biotype[feature_id]
-          #puts feature_id          
+          puts feature_id          
+          puts id2pos[feature_id][0]       
           pos_part = "<td class=\"\">#{$id2pos[feature_id][0]}:#{$id2pos[feature_id][1]}-#{$id2pos[feature_id][2]} (#{$id2pos[feature_id][3]})"
           if $ensembl_url
             if $exon_id_2_gene_id[feature_id]
@@ -224,7 +227,9 @@ class RefactorReportingtoolsTable
     end
     f.close
 
-    if ens_id == "na"
+    # check if id is a valid ensembl id
+    if (ens_id == "na") || !(ens_id.include? "ENS")
+      puts "Stopping ensembl stable ID lookup because #{ens_id} is not a valid ensembl ID. Continuing without lookup."
       return ""
     end
 
@@ -242,7 +247,7 @@ class RefactorReportingtoolsTable
       response = http.request(request)
       
       if response.code != "200"
-        puts "Invalid response: #{response.code}"
+        puts "Invalid response from ensembl REST API: #{response.code}"
         puts response.body
         return ""
       end

--- a/bin/refactor_reportingtools_table.rb
+++ b/bin/refactor_reportingtools_table.rb
@@ -160,8 +160,6 @@ class RefactorReportingtoolsTable
           feature_id = feature_id.gsub('"','')
           feature_name = $id2name[feature_id]
           gene_biotype = $id2biotype[feature_id]
-          puts feature_id          
-          puts id2pos[feature_id][0]       
           pos_part = "<td class=\"\">#{$id2pos[feature_id][0]}:#{$id2pos[feature_id][1]}-#{$id2pos[feature_id][2]} (#{$id2pos[feature_id][3]})"
           if $ensembl_url
             if $exon_id_2_gene_id[feature_id]

--- a/bin/refactor_reportingtools_table.rb
+++ b/bin/refactor_reportingtools_table.rb
@@ -100,8 +100,6 @@ class RefactorReportingtoolsTable
     end
   end
 
-  puts $id2pos
-  
   def add_plot_html_code(html_path, pvalue)
 
     pvalue_label = 'full'


### PR DESCRIPTION
- fix PCA plots to show more than one data point and one group
- stop ENS ID lookup in `refactor_reportingtools_table.rb` if ID is not a valid ENS ID, return more clear error message instead of REST API return code 
( `{"error":"ID 'NANOZOOG1' not found"}` -> `Stopping ensembl stable ID lookup because NANOZOOG1 is not a valid ensembl ID. Continuing without lookup.`)

closes #203 