### PR TITLE
Fix refactor_reportingtools_table.rb crash whenrun with non-ENS feature IDs and feature_type not 'gene'

### DIFF
--- a/bin/deseq2.R
+++ b/bin/deseq2.R
@@ -133,8 +133,7 @@ plot.pca <- function(out.dir, col.labels, trsf_data, trsf_type, ntop) {
   }
 
   d <- data.frame(PC1=pca$x[,1], PC2=pca$x[,2], group=group, intgroup.df, name=col.labels)
-  print("pca df is:")
-  print(d)
+
   ggplot(data=d, aes(x=PC1, y=PC2, colour=condition)) +
     geom_point(size=3) + 
     xlab(paste0("PC1: ",round(percentVar[1] * 100),"% variance")) +

--- a/bin/deseq2.R
+++ b/bin/deseq2.R
@@ -133,8 +133,9 @@ plot.pca <- function(out.dir, col.labels, trsf_data, trsf_type, ntop) {
   }
 
   d <- data.frame(PC1=pca$x[,1], PC2=pca$x[,2], group=group, intgroup.df, name=col.labels)
-
-  ggplot(data=d, aes(x="PC1", y="PC2", colour="condition")) +
+  print("pca df is:")
+  print(d)
+  ggplot(data=d, aes(x=PC1, y=PC2, colour=condition)) +
     geom_point(size=3) + 
     xlab(paste0("PC1: ",round(percentVar[1] * 100),"% variance")) +
     ylab(paste0("PC2: ",round(percentVar[2] * 100),"% variance")) +
@@ -143,6 +144,7 @@ plot.pca <- function(out.dir, col.labels, trsf_data, trsf_type, ntop) {
 
   ggsave(file = paste0("PCA_simple_", trsf_type, "_top", ntop, ".pdf"), device = "pdf", path = out.dir)
   ggsave(file = paste0("PCA_simple_", trsf_type, "_top", ntop, ".svg"), device = "svg", path = out.dir)
+  print(paste0("PCA_simple_", trsf_type, "_top", ntop, ".pdf"))
 }
 
 plot.heatmap.most_var <- function(out.dir, dds, trsf_data, trsf_type, ntop, samples.info=df.samples.info, genes.info=df.gene.anno) {

--- a/bin/piano.R
+++ b/bin/piano.R
@@ -30,7 +30,7 @@ try.biomart <- try(
     biomart.ensembl <- useMart('ensembl', dataset='mauratus_gene_ensembl')
   } else {
     biomart.ensembl <- NA
-    print('SKIPPING: BiomaRt. Species not accasible with BiomaRt.')
+    print('SKIPPING: BiomaRt. Species not accessible with BiomaRt.')
   }
 )
 if (class(try.biomart) == "try-error") {

--- a/bin/refactor_reportingtools_table.rb
+++ b/bin/refactor_reportingtools_table.rb
@@ -99,6 +99,8 @@ class RefactorReportingtoolsTable
       refactor_deseq_html_table(html_path)
     end
   end
+
+  puts $id2pos
   
   def add_plot_html_code(html_path, pvalue)
 
@@ -158,7 +160,8 @@ class RefactorReportingtoolsTable
           feature_id = feature_id.gsub('"','')
           feature_name = $id2name[feature_id]
           gene_biotype = $id2biotype[feature_id]
-          #puts feature_id          
+          puts feature_id          
+          puts id2pos[feature_id][0]       
           pos_part = "<td class=\"\">#{$id2pos[feature_id][0]}:#{$id2pos[feature_id][1]}-#{$id2pos[feature_id][2]} (#{$id2pos[feature_id][3]})"
           if $ensembl_url
             if $exon_id_2_gene_id[feature_id]
@@ -224,7 +227,9 @@ class RefactorReportingtoolsTable
     end
     f.close
 
-    if ens_id == "na"
+    # check if id is a valid ensembl id
+    if (ens_id == "na") || !(ens_id.include? "ENS")
+      puts "Stopping ensembl stable ID lookup because #{ens_id} is not a valid ensembl ID. Continuing without lookup."
       return ""
     end
 
@@ -242,7 +247,7 @@ class RefactorReportingtoolsTable
       response = http.request(request)
       
       if response.code != "200"
-        puts "Invalid response: #{response.code}"
+        puts "Invalid response from ensembl REST API: #{response.code}"
         puts response.body
         return ""
       end

--- a/bin/refactor_reportingtools_table.rb
+++ b/bin/refactor_reportingtools_table.rb
@@ -160,8 +160,6 @@ class RefactorReportingtoolsTable
           feature_id = feature_id.gsub('"','')
           feature_name = $id2name[feature_id]
           gene_biotype = $id2biotype[feature_id]
-          puts feature_id          
-          puts id2pos[feature_id][0]       
           pos_part = "<td class=\"\">#{$id2pos[feature_id][0]}:#{$id2pos[feature_id][1]}-#{$id2pos[feature_id][2]} (#{$id2pos[feature_id][3]})"
           if $ensembl_url
             if $exon_id_2_gene_id[feature_id]

--- a/bin/refactor_reportingtools_table.rb
+++ b/bin/refactor_reportingtools_table.rb
@@ -100,8 +100,6 @@ class RefactorReportingtoolsTable
     end
   end
 
-  puts $id2pos
-  
   def add_plot_html_code(html_path, pvalue)
 
     pvalue_label = 'full'

--- a/bin/refactor_reportingtools_table.rb
+++ b/bin/refactor_reportingtools_table.rb
@@ -170,13 +170,13 @@ class RefactorReportingtoolsTable
             end
 
           end
-          
+
           next unless feature_id
           feature_id = feature_id.gsub('"','')
           feature_name = $id2name[feature_id]
           gene_biotype = $id2biotype[feature_id]
 
-          pos_part = "<td class=\"\">#{$id2pos[feature_id][1]}:#{$id2pos[feature_id][1]}-#{$id2pos[feature_id][2]} (#{$id2pos[feature_id][3]})"
+          pos_part = "<td class=\"\">#{$id2pos[feature_id][0]}:#{$id2pos[feature_id][1]}-#{$id2pos[feature_id][2]} (#{$id2pos[feature_id][3]})"
           if $ensembl_url
             if $exon_id_2_gene_id[feature_id]
               # in this case we write the exon gene ID but want to point to the ENSEMBL gene URL

--- a/bin/webgestalt.R
+++ b/bin/webgestalt.R
@@ -41,4 +41,6 @@ if (! is.na(organism)) {
     } else {
         print(paste('SKIPPING: WebGestaltR. Feature ID', id_type, 'not supported.'))
     }
+} else {
+    print("Unknown organism, only organisms 'hsapiens' and 'mmusculus' are supported by default. Exiting.")
 }

--- a/modules/piano.nf
+++ b/modules/piano.nf
@@ -18,7 +18,7 @@ process piano {
     path("piano")
     
     script:
-    comparison = resFold05.toString().findAll("[a-zA-Z]*_vs_[a-zA-Z]*")[0]
+    comparison = resFold05.toString().split("deseq2_")[1].split("_filtered")[0]
 
     """
     R CMD BATCH --no-save --no-restore '--args c(".") c("${resFold05}") c("${species}") c("${id_type}") c("${task.cpus}")' ${piano_script}

--- a/modules/webgestalt.nf
+++ b/modules/webgestalt.nf
@@ -17,7 +17,7 @@ process webgestalt {
     path("WebGestalt") optional true
     
     script:
-    comparison = resFold05.toString().findAll("[a-zA-Z]*_vs_[a-zA-Z]*")[0]
+    comparison = resFold05.toString().split("deseq2_")[1].split("_filtered")[0]//findAll("[a-zA-Z]*_vs_[a-zA-Z]*")[0]
     """
     R CMD BATCH --no-save --no-restore '--args c(".") c("${resFold05}") c("${species}") c("${id_type}")' ${webgestalt_script}
     """


### PR DESCRIPTION
When we know we have valid ENS IDs we can use the features ENS stable ID prefix (ENSG, ENST etc.) to scan for the gene ID in the HTML report from reporting tools. This fails with arbitrary IDs if the feature the GTF was filtered for is not also the gene ID because we then have a gene ID from the reporting tools report and an exon / transcript ID from the filtered GTF that we cant map to each other.

- added valid ENS ID check
- added additional mapping from gene ID to feature ID from the GTF file to later map to the feature name, gene biotype and features position in case non-ENS IDs were detected and standard mapping fails (feature type is not 'gene')

closes #204 