### PR TITLE
fix strandness logic so that the CSV definition can be correctly over…

### DIFF
--- a/test-data/input.se.hsa_small.csv
+++ b/test-data/input.se.hsa_small.csv
@@ -1,5 +1,5 @@
 Sample,R1,R2,Condition,Source,Strandedness
-MAQCA_rep1,test-data/hsa/SRR3670977_sub.fastq.gz,,MAQCA,,0
-MAQCA_rep2,test-data/hsa/SRR3670978_sub.fastq.gz,,MAQCA,,0
-MAQCB_rep1,test-data/hsa/SRR3670985_sub.fastq.gz,,MAQCB,,0
-MAQCB_rep2,test-data/hsa/SRR3670986_sub.fastq.gz,,MAQCB,,0
+MAQCA_rep1,test-data/hsa/SRR3670977_sub.fastq.gz,,MAQCA,,1
+MAQCA_rep2,test-data/hsa/SRR3670978_sub.fastq.gz,,MAQCA,,1
+MAQCB_rep1,test-data/hsa/SRR3670985_sub.fastq.gz,,MAQCB,,1
+MAQCB_rep2,test-data/hsa/SRR3670986_sub.fastq.gz,,MAQCB,,1


### PR DESCRIPTION
…written when --strand 0 is used.

The problem was that in the previous logic, a `--strand 0` was interpreted as `false` in Groovy, and thus the value in the Strandness column in the CSV file was not correctly overwritten. Thus, the pipeline might have run with the value defined in the CSV instead of the value specified on the command line. 

This is fixed now by checking the length of the `--strand` value to first see if it was set to something larger the empty string (default) and then evaluating if it is 0,1,2 and different from the CSV input. Then, the warning message is set accordingly and the `--strand` value is used if set correctly and different from the CSV value. 