### PR TITLE
SortMeRNA refactor + update

### DIFF
--- a/configs/container.config
+++ b/configs/container.config
@@ -9,7 +9,7 @@ process {
     withLabel:	subread	{ container = "nanozoo/subread:2.0.1--713a8e7" } 
     withLabel:	multiqc	{ container = "nanozoo/multiqc:1.12--4f89fda" } 
     withLabel:	nanoplot	{ container = "nanozoo/nanoplot:1.38.1--e303519" }
-    withLabel:	sortmerna	{ container = "nanozoo/sortmerna:2.1b--ceea1a1" } 
+    withLabel:	sortmerna	{ container = "nanozoo/sortmerna:4.3.4--7b48a67" } 
     withLabel:	trinity	{ container = "trinityrnaseq/trinityrnaseq:2.13.2" } 
     withLabel:	stringtie	{ container = "nanozoo/stringtie:2.1.7--420b0db" } 
     withLabel:	busco	{ container = "ezlabgva/busco:v5.2.1_cv1" } 

--- a/main.nf
+++ b/main.nf
@@ -584,7 +584,7 @@ workflow preprocess_illumina {
             sortmerna_log = Channel.empty()
         } else {
             // remove rRNA with SortmeRNA
-            sortmerna(smr_in, extract_tar_bz2(sortmerna_db))
+            sortmerna(smr_in, sortmerna_db)
             sortmerna_no_rna_fastq = sortmerna.out.no_rna_fastq
             sortmerna_log = sortmerna.out.log
         }
@@ -624,7 +624,7 @@ workflow preprocess_nanopore {
             sortmerna_log = Channel.empty()
         } else {
             // remove rRNA with SortmeRNA
-            sortmerna(read_input_ch, extract_tar_bz2(sortmerna_db))
+            sortmerna(read_input_ch, sortmerna_db)
             sortmerna_no_rna_fastq = sortmerna.out.no_rna_fastq
             sortmerna_log = sortmerna.out.log
         }

--- a/modules/sortmernaGet.nf
+++ b/modules/sortmernaGet.nf
@@ -9,16 +9,15 @@ process sortmernaGet {
     else { storeDir "${params.permanentCacheDir}/databases/sortmerna/" }  
 
     output:
-    path("rRNA_databases.tar.gz")
+    path("database.tar.gz")
 
     script:
     """
-    git clone https://github.com/biocore/sortmerna.git
-    indexdb_rna --ref ./sortmerna/data/rRNA_databases/silva-bac-16s-id90.fasta,./sortmerna/data/rRNA_databases/silva-bac-16s-id90:./sortmerna/data/rRNA_databases/silva-bac-23s-id98.fasta,./sortmerna/data/rRNA_databases/silva-bac-23s-id98:./sortmerna/data/rRNA_databases/silva-arc-16s-id95.fasta,./sortmerna/data/rRNA_databases/silva-arc-16s-id95:./sortmerna/data/rRNA_databases/silva-arc-23s-id98.fasta,./sortmerna/data/rRNA_databases/silva-arc-23s-id98:./sortmerna/data/rRNA_databases/silva-euk-18s-id95.fasta,./sortmerna/data/rRNA_databases/silva-euk-18s-id95:./sortmerna/data/rRNA_databases/silva-euk-28s-id98.fasta,./sortmerna/data/rRNA_databases/silva-euk-28s-id98:./sortmerna/data/rRNA_databases/rfam-5s-database-id98.fasta,./sortmerna/data/rRNA_databases/rfam-5s-database-id98:./sortmerna/data/rRNA_databases/rfam-5.8s-database-id98.fasta,./sortmerna/data/rRNA_databases/rfam-5.8s-database-id98 -v
-    mv sortmerna/data/rRNA_databases . 
-    tar zcvf rRNA_databases.tar.gz rRNA_databases
-    rm -r rRNA_databases
-    rm -r sortmerna
+	# Database Files (sorted by type and how fast they are)
+	# smr_v4.3_fast_db.fasta / smr_v4.3_default_db.fasta
+	# smr_v4.3_sensitive_db_rfam_seeds.fasta / smr_v4.3_sensitive_db.fasta 
+
+        wget https://github.com/biocore/sortmerna/releases/download/v4.3.4/database.tar.gz
     """
     }
 


### PR DESCRIPTION
Hey, 

I've updated SortMeRNA to a more recent version to tackle those potential issues we discussed with uneven paired reads. Turns out, the HISAT2 memory problem we saw earlier was a false alarm – it was actually due to SortMeRNA corrupting files, which others have also reported in issues #116 and #141 . This update to SortMeRNA seems to have resolved that, and the previously corrupted files are now processing correctly.

Because of some changes in SortMeRNA's database and flags, I had to make a few adjustments in sortmerna.nf, sortmernaGet.nf, and the database packing in main.nf. I've made sure that everything remains compatible with the old output structure.

A heads-up on the database: SortMeRNA now offers databases in four different types (you can see the details here: https://github.com/sortmerna/sortmerna?tab=readme-ov-file#databases). I've used smr_v4.3_default_db.fasta for this update, but switching to a different database type should be straightforward, just requiring a change to the pointed database.

I tested the data with previously misbehaving Illumina paired and single reads, and everything appears to be working as expected.

Let me know what you think or if you want any changes